### PR TITLE
Hotfix/v063

### DIFF
--- a/chrome_extension/js/cart_functions.js
+++ b/chrome_extension/js/cart_functions.js
@@ -43,12 +43,10 @@ function showCart(){
     oldCart.insertAdjacentHTML('afterbegin',newCart);
 }
 
-let metodo = localStorage.getItem('steamcito-payment') == "mercadopago" ? " prepaga MercadoPago" : "";
-
 function showTaxes(){
     let taxesContainer = 
     `<div class="tax-container">
-        <h3>¿Qué impuestos me cobran pagando con tarjeta${metodo}?</h3>
+        <h3>¿Qué impuestos me cobran pagando con tarjeta?</h3>
         <ul></ul>
         <span class="final-total">Carga Impositiva Total ${((totalTaxes-1)*100).toFixed(2)}%</span>
         <p id="tax-change">Personalizar impuestos</p>

--- a/chrome_extension/js/data.js
+++ b/chrome_extension/js/data.js
@@ -18,24 +18,6 @@ const standardTaxes = [
     }
 ];
 
-const mpTaxes = [
-    {
-        name : "IVA Servicios Digitales - RG AFIP N° 4240/2018",
-        value : 19.09,
-        moreInfo: "http://biblioteca.afip.gob.ar/dcp/REAG01004240_2018_05_11"
-    },
-    {
-        name : "Impuesto PAIS - RG AFIP N° 4659/2020",
-        value : 7.27,
-        moreInfo: "http://biblioteca.afip.gob.ar/dcp/REAG01004659_2020_01_06"
-    },
-    {
-        name : "Retención del Impuesto a las ganancias - RG AFIP Nº 4815/2020",
-        value : 31.82,
-        moreInfo: "https://www.boletinoficial.gob.ar/detalleAviso/primera/235038/20200916"
-    }
-];
-
 const cabaTaxes = [
     {
         name : "Impuesto de Sellos - LEY N° 6382/2021 - Art. 447 Bis",
@@ -78,7 +60,7 @@ function setTax(){
         return standardTaxes;
     }
 
-    return mpTaxes;
+    return standardTaxes;
 }
 
 let taxes = setTax();

--- a/chrome_extension/js/menu.js
+++ b/chrome_extension/js/menu.js
@@ -29,17 +29,6 @@ function createMenus(){
 
                     <div class="opcion">
                         <div>
-                            <label>Modo MercadoPago</label>
-                            <select name="steamcito-payment" id="steamcito-payment">
-                                <option value="desactivado">Desactivado</option>
-                                <option value="activado">Activado</option>
-                            </select>
-                        </div>
-                        <small>Activá esta opción si pagás con la tarjeta prepaga de MercadoPago. <a target="_blank" href='https://emilianog94.github.io/Steamcito-Precios-Steam-Argentina-Impuestos-Incluidos/landing/funcionalidad-mercadopago.html' style="display:inline">¿Porqué MercadoPago tiene menos impuestos?</a></small>
-                    </div>
-
-                    <div class="opcion">
-                        <div>
                             <label>Impuesto de Sellos CABA 2021</label>
                             <select name="steamcito-caba" id="steamcito-caba">
                                 <option value="desactivado">Desactivado</option>
@@ -73,20 +62,8 @@ function getReviewLink(){
 }
 
 function setInitialLocalStates(){
-    localStorage.getItem('steamcito-payment') == 'standard' ? selectPayment.value='desactivado' : selectPayment.value='activado';
     localStorage.getItem('steamcito-emoji') == 'unicode' ? selectEmoji.value='unicode' : selectEmoji.value='fallback';
     localStorage.getItem('steamcito-caba') == 'activado' ? selectCaba.value='activado' : selectCaba.value='desactivado';
-}
-
-function changePaymentState(){
-    if(selectPayment.value == 'desactivado'){
-        localStorage.setItem('steamcito-payment','standard');
-    } else{
-        localStorage.setItem('steamcito-payment','mercadopago');
-        localStorage.setItem('steamcito-caba','desactivado');
-        selectCaba.value="desactivado";
-    }
-
 }
 
 function changeEmojiState(){
@@ -98,8 +75,6 @@ function changeCabaState(){
         localStorage.setItem('steamcito-caba','desactivado');
     } else{
         localStorage.setItem('steamcito-caba','activado');
-        localStorage.setItem("steamcito-payment","standard");
-        selectPayment.value="desactivado";
     }
 }
 
@@ -147,10 +122,8 @@ createMenus();
 // Selecciono los botones del menú y les asigno eventos
 const menu = document.querySelector(".menu-steamcito");
 const steamcitoIcon = document.querySelector(".ico-steamcito");
-let selectPayment = document.querySelector('#steamcito-payment');
 let selectCaba = document.querySelector('#steamcito-caba');
 let selectEmoji = document.querySelector("#estilo-emoji");
-selectPayment.addEventListener('input',changePaymentState);
 selectEmoji.addEventListener('input',changeEmojiState);
 selectCaba.addEventListener('input',changeCabaState);
 

--- a/chrome_extension/js/menu.js
+++ b/chrome_extension/js/menu.js
@@ -81,7 +81,6 @@ function changeCabaState(){
 function showMenu(e){
     menu.classList.add('enabled');
     document.addEventListener('click',hideMenu);
-    console.log("clickee el mate");
 }
 
 function hideMenu(e){

--- a/landing/changelog.html
+++ b/landing/changelog.html
@@ -64,17 +64,10 @@
     <div class="row">
       <div class="col-md-8 mb-4">
         <h3>Última versión de Steamcito</h3>
-        <p><b class="text-success">Steamcito v0.62</b> (04/01/2021)</p>
+        <p><b class="text-success">Steamcito v0.63</b> (05/02/2021) - Muy pronto en Chrome Store y Mozilla Addons</p>
 
         <ul>
-          <li>- <b>Nueva Funcionalidad: </b> se agregó una opción para habilitar el nuevo impuesto de sellos del 1.2% que entró en vigencia el 01/01/2021 para todos los residentes de CABA que abonen con tarjeta de crédito. <a href="impuesto-sellos-steam-2021-caba.html">Ver más información sobre este nuevo impuesto.</a> </li>
-          <img class="img-fluid rounded-image mb-4" src="img/updates/v062-1.png" alt="">
-
-          <li>- <b>Nueva Funcionalidad: </b> Se añadió un botón de acceso directo en la sección Carrito para personalizar los impuestos.</li>
-          <br>
-
-          <li>- <b>Nueva Funcionalidad</b> Steamcito ahora funciona en las Item Stores de los juegos.</li>
-          <img class="img-fluid rounded-image mb-4" src="img/updates/v062-2.png" alt="">
+          <li>- <b>Hotfix: </b> se eliminó la funcionalidad "Modo MercadoPago" ya que MercadoPago comenzó a cobrar correctamente el importe de los impuestos nacionales. Si tenías la funcionalidad activada, al actualizar la extensión la misma se desactivará automáticamente para mostrarte el importe correcto.</li>
         </ul>
 
       </div>
@@ -88,6 +81,35 @@
 
       <div class="col-md-8">
         <div id="accordion">
+
+          <div class="card">
+            <div class="card-header" id="heading13">
+              <h5 class="mb-0">
+                <button class="btn btn-link" data-toggle="collapse" data-target="#collapse13" aria-expanded="false"
+                  aria-controls="collapse13">
+                  Steamcito v0.62 (04/01/2021)
+                </button>
+              </h5>
+            </div>
+
+            <div id="collapse13" class="collapse" aria-labelledby="heading13" data-parent="#accordion">
+              <div class="card-body">
+
+                <ul>
+                  <li>- <b>Nueva Funcionalidad: </b> se agregó una opción para habilitar el nuevo impuesto de sellos del 1.2% que entró en vigencia el 01/01/2021 para todos los residentes de CABA que abonen con tarjeta de crédito. <a href="impuesto-sellos-steam-2021-caba.html">Ver más información sobre este nuevo impuesto.</a> </li>
+                  <img class="img-fluid rounded-image mb-4" src="img/updates/v062-1.png" alt="">
+        
+                  <li>- <b>Nueva Funcionalidad: </b> Se añadió un botón de acceso directo en la sección Carrito para personalizar los impuestos.</li>
+                  <br>
+        
+                  <li>- <b>Nueva Funcionalidad</b> Steamcito ahora funciona en las Item Stores de los juegos.</li>
+                  <img class="img-fluid rounded-image mb-4" src="img/updates/v062-2.png" alt="">
+                </ul>
+
+              </div>
+            </div>
+          </div>
+
 
           <div class="card">
             <div class="card-header" id="heading12">

--- a/landing/funcionalidad-mercadopago.html
+++ b/landing/funcionalidad-mercadopago.html
@@ -52,6 +52,11 @@
             <div class="col-md-10 mb-4">
                 <h3 class="text-success">¿Qué es la funcionalidad MercadoPago?</h3>
                 <small>Incluida en Steamcito a partir de la versión v0.5 del 03/12/2020.</small>
+
+                <br><br>
+
+              <div class="alert alert-danger">Esta funcionalidad fue eliminada de Steamcito a partir de la versión v0.63 del 05/02/2021 ya que MercadoPago actualizó su sistema y comenzó a cobrar correctamente el importe del 64%.</div>
+
             </div>
 
 


### PR DESCRIPTION
De acuerdo a reportes recibidos, a inicios de Febrero MercadoPago solucionó el problema de los impuestos, y comenzó a cobrar el importe correcto de 64%. Anteriormente, cobraba un 58.18%

Se actualizó la extensión para eliminar la funcionalidad de MercadoPago. 
Si tenías la funcionalidad activa, la misma se desactivará automáticamente tras la actualización para tu comodidad.