### PR TITLE
Feature/v310

### DIFF
--- a/chrome_extension/js/global_functions.js
+++ b/chrome_extension/js/global_functions.js
@@ -18,17 +18,9 @@ function getPrices(){
 async function setArgentinaPrice(price){
     let exchangeRate = JSON.parse(localStorage.getItem('steamcito-cotizacion')).rate;
 
-    if(price.innerText.includes("ARS$") && price.hasChildNodes()){
-        let positionArs = price.innerText.lastIndexOf("ARS$ ") + 5;
-        let baseNumericPrice = stringToNumber(price,positionArs);
-        price.dataset.originalPrice = baseNumericPrice.toFixed(2);
-        price.dataset.argentinaPrice = calcularImpuestos(baseNumericPrice);
-        price.dataset.isDolarized = "not-dolarized";
-        renderPrices(price);
-    }
 
     // Update 20/11 si los precios están en una currency distinta a ARS
-    else if(price.innerText.includes("$")){
+    if(price.innerText.includes("$")){
         let baseNumericPrice = extractNumberFromString(price.innerText)
         price.dataset.originalPrice = baseNumericPrice;
         price.dataset.argentinaPrice = calculateTaxesAndExchange(baseNumericPrice,exchangeRate);

--- a/chrome_extension/js/helpers.js
+++ b/chrome_extension/js/helpers.js
@@ -506,11 +506,14 @@ function isStoreDolarized(){
 }
 
 function extractNumberFromString(string){
-    let regexFindNumber = /(\d+\.\d+)/;
+    let regexFindNumber = /(\d{1,3}(,\d{3})*(\.\d+)?)/;
     let match = string.match(regexFindNumber);
+    console.log("match es");
+    console.log(match);
     if(match){
-        return match[0];
+        return match[0].replace(/,/g, '');
     }
+
 
 }
 

--- a/chrome_extension/js/regional_indicator.js
+++ b/chrome_extension/js/regional_indicator.js
@@ -254,7 +254,7 @@ const renderRegionalIndicator = (appData, exchangeRate) => {
         </p>
         <hr>
         <p class="reason info">
-        <span class="name-span">${appData.publisher}</span> cargó manualmente un precio más barato que el sugerido. <br><br> ¡Muchas gracias ${appData.publisher}!
+        <span class="name-span">${appData.publisher}</span> cargó manualmente un precio más barato que el sugerido. <br><br> ¡Te quiero mucho ${appData.publisher}!
         </p>
         <hr>
         <p class="reason info">

--- a/chrome_extension/js/regional_indicator.js
+++ b/chrome_extension/js/regional_indicator.js
@@ -216,7 +216,7 @@ const renderRegionalIndicator = (appData, exchangeRate) => {
                 ""
             }
 
-            ${appData.arsPrice < appData.recommendedArsPrice
+            ${appData.arsPrice < appData.recommendedArsPrice && appData.regionalDifference != 0
                 ?
                 `
             <p class="reason info">

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,6 +1,6 @@
  {
  	"name": "Steamcito: Steam con impuestos Argentina 2023",
- 	"version": "3.0",
+ 	"version": "3.10",
  	"description": "Muestra todos los productos de la tienda de Steam con todos los impuestos de Argentina incluidos",
  	"manifest_version": 3,
  	"background": {

--- a/firefox_extension/js/global_functions.js
+++ b/firefox_extension/js/global_functions.js
@@ -17,17 +17,10 @@ function getPrices(){
 async function setArgentinaPrice(price){
     let exchangeRate = JSON.parse(localStorage.getItem('steamcito-cotizacion')).rate;
 
-    if(price.innerText.includes("ARS$") && price.hasChildNodes()){
-        let positionArs = price.innerText.lastIndexOf("ARS$ ") + 5;
-        let baseNumericPrice = stringToNumber(price,positionArs);
-        price.dataset.originalPrice = baseNumericPrice.toFixed(2);
-        price.dataset.argentinaPrice = calcularImpuestos(baseNumericPrice);
-        price.dataset.isDolarized = "not-dolarized";
-        renderPrices(price);
-    }
+
 
     // Update 20/11 si los precios están en una currency distinta a ARS
-    else if(price.innerText.includes("$")){
+    if(price.innerText.includes("$")){
         let baseNumericPrice = extractNumberFromString(price.innerText)
         price.dataset.originalPrice = baseNumericPrice;
         price.dataset.argentinaPrice = calculateTaxesAndExchange(baseNumericPrice,exchangeRate);

--- a/firefox_extension/js/helpers.js
+++ b/firefox_extension/js/helpers.js
@@ -511,12 +511,13 @@ function isStoreDolarized(){
 }
 
 function extractNumberFromString(string){
-    let regexFindNumber = /(\d+\.\d+)/;
+    let regexFindNumber = /(\d{1,3}(,\d{3})*(\.\d+)?)/;
     let match = string.match(regexFindNumber);
+    console.log("match es");
+    console.log(match);
     if(match){
-        return match[0];
+        return match[0].replace(/,/g, '');
     }
-
 }
 
 

--- a/firefox_extension/js/regional_indicator.js
+++ b/firefox_extension/js/regional_indicator.js
@@ -211,7 +211,7 @@ const renderRegionalIndicator = (appData,exchangeRate) => {
                 :
                 ""
             }
-            ${appData.arsPrice < appData.recommendedArsPrice
+            ${appData.arsPrice < appData.recommendedArsPrice && appData.regionalDifference != 0
                 ?
                 `
             <p class="reason info">

--- a/firefox_extension/manifest.json
+++ b/firefox_extension/manifest.json
@@ -1,6 +1,6 @@
  {
  	"name": "Steamcito: Steam con impuestos Argentina 2023",
- 	"version": "3.0",
+ 	"version": "3.10",
  	"description": "Muestra todos los productos de la tienda de Steam con todos los impuestos de Argentina incluidos",
  	"manifest_version": 2,
  	"background": {


### PR DESCRIPTION

<b>Feature:</b> Se reestablece la funcionalidad indicadora de precios regionales relativos en la barra lateral de todos los juegos. Estos son los estados posibles: <br>
- Barato: Si el juego es a partir de un 25% más barato que lo sugerido por Valve<br>
- Adecuado: Si el juego es a partir de un 24% más barato que lo sugerido hasta un 35% más caro que lo sugerido.<br>
- Caro: Si el juego es desde un 36% más caro que lo sugerido por Valve.<br><br>

<b> Enhancement:</b> Se agregó un indicador que avisa si el juego está exactamente al mismo precio que Estados Unidos, esto significa que hay una posibilidad muy grande de que el publisher no cargó ningún precio y hay esperanza de que sea actualizado en el futuro.

<b> Fix: Se corrige comportamiento de conversión cuando el juego que estás viendo es mayor a 999.99 USD</b>





