### PR TITLE
Agregar boton: Enviar mail para solicitar precio regional (mailto)

### DIFF
--- a/chrome_extension/js/regional_indicator.js
+++ b/chrome_extension/js/regional_indicator.js
@@ -355,10 +355,10 @@ const renderRegionalIndicator = (appData, exchangeRate) => {
                     }  
                     ${appData.support_email 
 						? `<button class="copiar-texto-steamcito green-steamcito-button" type="button" data-clipboard="publisher-email">Copiar</button>
-						<button class="copiar-texto-steamcito green-steamcito-button" type="button" onclick="window.location.href='mailto:${appData.support_email}?subject=Question about new regional pricing on ${appData.name}&body=Hi there!%0A%0A` + 
+						<button class="copiar-texto-steamcito green-steamcito-button" type="button" onclick="window.open('mailto:${appData.support_email}?subject=Question about new regional pricing on ${appData.name}&body=Hi there!%0A%0A` + 
 						`I%27m a Steam user and I would like to bring something to your attention that may have been overlooked. Recently, Steam introduced a new region called LATAM which includes many countries in Latin America, including my country, Argentina.%0A%0A` +
 						`Currently, ${appData.name} seems to have inherited the standard price in the United States since no price was set for our region.%0A%0AWould you please consider setting a price for our region when you get a chance? This would be greatly appreciated by players across Latin America!%0A%0A` +
-						`Kind regards,';">Enviar Mail</button>` 
+						`Kind regards,');">Enviar Mail</button>` 
 						: ""
 					}
                 </div>

--- a/chrome_extension/js/regional_indicator.js
+++ b/chrome_extension/js/regional_indicator.js
@@ -353,14 +353,7 @@ const renderRegionalIndicator = (appData, exchangeRate) => {
                         ? `<p class="publisher-email">${appData.support_email}</p>`
                         : `<a target=_blank href="${appData.support_url}">${appData.support_url}</a>`
                     }  
-                    ${appData.support_email 
-						? `<button class="copiar-texto-steamcito green-steamcito-button" type="button" data-clipboard="publisher-email">Copiar</button>
-						<button class="copiar-texto-steamcito green-steamcito-button" type="button" onclick="window.open('mailto:${appData.support_email}?subject=Question about new regional pricing on ${appData.name}&body=Hi there!%0A%0A` + 
-						`I%27m a Steam user and I would like to bring something to your attention that may have been overlooked. Recently, Steam introduced a new region called LATAM which includes many countries in Latin America, including my country, Argentina.%0A%0A` +
-						`Currently, ${appData.name} seems to have inherited the standard price in the United States since no price was set for our region.%0A%0AWould you please consider setting a price for our region when you get a chance? This would be greatly appreciated by players across Latin America!%0A%0A` +
-						`Kind regards,');">Enviar Mail</button>` 
-						: ""
-					}
+                    ${appData.support_email ? `<button class="copiar-texto-steamcito green-steamcito-button" type="button" data-clipboard="publisher-email">Copiar</button>` : ""}
                 </div>
 
             </div>
@@ -408,8 +401,26 @@ const renderRegionalIndicator = (appData, exchangeRate) => {
                     Kind regards,
                 </p>
             </div>
-        </div>
-
+			
+			${appData.support_email ? 
+			`<hr>
+			<div class="email-send-container">
+				<h5>Enviar mail a a ${appData.publisher}</h5> 
+				<div class="publisher-popup-flex-container">
+					<p><a href="https://www.activationtrouble.com/es/use-gmail-para-abrir-el-enlace-mailto-enviar-correo-a-en-la-pc" target="_blank">Configurar link de "enviar correo a"</a></p>&emsp;
+					<button class="copiar-texto-steamcito green-steamcito-button" type="button" onclick="window.open('mailto:${appData.support_email}?subject=Question about new regional pricing on ${appData.name}&body=Hi there!%0A%0A` + 
+					`I%27m a Steam user and I would like to bring something to your attention that may have been overlooked. Recently, Steam introduced a new region called LATAM which includes many countries in Latin America, including my country, Argentina.%0A%0A` +
+					`Currently, ${appData.name} seems to have inherited the standard price in the United States since no price was set for our region.%0A%0AWould you please consider setting a price for our region when you get a chance? This would be greatly appreciated by players across Latin America!%0A%0A` +
+					`Kind regards,');">Enviar</button>
+				</div>
+			</div>
+			`
+			:
+			""
+			}
+		
+		</div>
+		
         `
 
         :

--- a/chrome_extension/js/regional_indicator.js
+++ b/chrome_extension/js/regional_indicator.js
@@ -401,26 +401,26 @@ const renderRegionalIndicator = (appData, exchangeRate) => {
                     Kind regards,
                 </p>
             </div>
-			
-			${appData.support_email ? 
-			`<hr>
-			<div class="email-send-container">
-				<h5>Enviar mail a a ${appData.publisher}</h5> 
-				<div class="publisher-popup-flex-container">
-					<p><a href="https://www.activationtrouble.com/es/use-gmail-para-abrir-el-enlace-mailto-enviar-correo-a-en-la-pc" target="_blank">Configurar link de "enviar correo a"</a></p>&emsp;
-					<button class="copiar-texto-steamcito green-steamcito-button" type="button" onclick="window.open('mailto:${appData.support_email}?subject=Question about new regional pricing on ${appData.name}&body=Hi there!%0A%0A` + 
-					`I%27m a Steam user and I would like to bring something to your attention that may have been overlooked. Recently, Steam introduced a new region called LATAM which includes many countries in Latin America, including my country, Argentina.%0A%0A` +
-					`Currently, ${appData.name} seems to have inherited the standard price in the United States since no price was set for our region.%0A%0AWould you please consider setting a price for our region when you get a chance? This would be greatly appreciated by players across Latin America!%0A%0A` +
-					`Kind regards,');">Enviar</button>
-				</div>
-			</div>
-			`
-			:
-			""
-			}
-		
-		</div>
-		
+            
+            ${appData.support_email ? 
+            `<hr>
+            <div class="email-send-container">
+                <h5>Enviar mail a a ${appData.publisher}</h5> 
+                <div class="publisher-popup-flex-container">
+                    <p><a href="https://www.activationtrouble.com/es/use-gmail-para-abrir-el-enlace-mailto-enviar-correo-a-en-la-pc" target="_blank">Configurar link de "enviar correo a"</a></p>&emsp;
+                    <button class="copiar-texto-steamcito green-steamcito-button" type="button" onclick="window.open('mailto:${appData.support_email}?subject=Question about new regional pricing on ${appData.name}&body=Hi there!%0A%0A` + 
+                    `I%27m a Steam user and I would like to bring something to your attention that may have been overlooked. Recently, Steam introduced a new region called LATAM which includes many countries in Latin America, including my country, Argentina.%0A%0A` +
+                    `Currently, ${appData.name} seems to have inherited the standard price in the United States since no price was set for our region.%0A%0AWould you please consider setting a price for our region when you get a chance? This would be greatly appreciated by players across Latin America!%0A%0A` +
+                    `Kind regards,');">Enviar</button>
+                </div>
+            </div>
+            `
+            :
+            ""
+            }
+        
+        </div>
+        
         `
 
         :

--- a/chrome_extension/js/regional_indicator.js
+++ b/chrome_extension/js/regional_indicator.js
@@ -353,7 +353,14 @@ const renderRegionalIndicator = (appData, exchangeRate) => {
                         ? `<p class="publisher-email">${appData.support_email}</p>`
                         : `<a target=_blank href="${appData.support_url}">${appData.support_url}</a>`
                     }  
-                    ${appData.support_email ? `<button class="copiar-texto-steamcito green-steamcito-button" type="button" data-clipboard="publisher-email">Copiar</button>` : ""}
+                    ${appData.support_email 
+						? `<button class="copiar-texto-steamcito green-steamcito-button" type="button" data-clipboard="publisher-email">Copiar</button>
+						<button class="copiar-texto-steamcito green-steamcito-button" type="button" onclick="window.location.href='mailto:${appData.support_email}?subject=Question about new regional pricing on ${appData.name}&body=Hi there!%0A%0A` + 
+						`I%27m a Steam user and I would like to bring something to your attention that may have been overlooked. Recently, Steam introduced a new region called LATAM which includes many countries in Latin America, including my country, Argentina.%0A%0A` +
+						`Currently, ${appData.name} seems to have inherited the standard price in the United States since no price was set for our region.%0A%0AWould you please consider setting a price for our region when you get a chance? This would be greatly appreciated by players across Latin America!%0A%0A` +
+						`Kind regards,';">Enviar Mail</button>` 
+						: ""
+					}
                 </div>
 
             </div>


### PR DESCRIPTION
Agregue un boton para enviar directamente el mail con mailto en una nueva pestaña.

![Opera Snapshot_2023-12-07_134407_store steampowered com](https://github.com/emilianog94/Steamcito-Precios-Steam-Argentina-Impuestos-Incluidos/assets/131562345/36dbd247-f9a8-4acd-9c55-2a8314a015a2)

[Link Configuracion mailto](https://www.activationtrouble.com/es/use-gmail-para-abrir-el-enlace-mailto-enviar-correo-a-en-la-pc)

![Opera Snapshot_2023-12-06_200211_store steampowered com](https://github.com/emilianog94/Steamcito-Precios-Steam-Argentina-Impuestos-Incluidos/assets/131562345/624a4a4b-b5e1-4971-ab53-0ee1e06443a1)
