### PR TITLE
Hotfix/v322

### DIFF
--- a/chrome_extension/js/cart_functions.js
+++ b/chrome_extension/js/cart_functions.js
@@ -52,7 +52,7 @@
     
     function showCart() {
         
-        let estimatedTotalDisplay = walletBalance < cartTotal ? "hide" : "show";
+        let estimatedTotalDisplay = walletBalance < parseFloat(cartTotal) ? "hide" : "show";
         let totalMixedDisplay = estimatedTotalDisplay == "hide" && walletBalance != 0 ? "show" : "hide";
     
         let newCart =

--- a/chrome_extension/js/global_functions.js
+++ b/chrome_extension/js/global_functions.js
@@ -18,16 +18,13 @@ function getPrices(){
 async function setArgentinaPrice(price){
     let exchangeRate = JSON.parse(localStorage.getItem('steamcito-cotizacion')).rate;
 
-
-    // Update 20/11 si los precios están en una currency distinta a ARS
-    if(price.innerText.includes("$")){
-        let baseNumericPrice = extractNumberFromString(price.innerText)
-        price.dataset.originalPrice = baseNumericPrice;
-        price.dataset.argentinaPrice = calculateTaxesAndExchange(baseNumericPrice,exchangeRate);
-        price.dataset.isDolarized = "dolarized";
-        renderPrices(price);
-    }
-
+        // Ignoro los juegos sin precio (Ejemplo: F2Ps)
+        if(price.innerText.includes('$')){
+            let baseNumericPrice = extractNumberFromString(price.innerText)
+            price.dataset.originalPrice = baseNumericPrice;
+            price.dataset.argentinaPrice = calculateTaxesAndExchange(baseNumericPrice,exchangeRate);
+            renderPrices(price);
+        }
 }
 
 function sanitizePromoLists(){
@@ -38,63 +35,49 @@ function sanitizePromoLists(){
 function renderPrices(price){
 
     let argentinaPrice = numberToString(price.dataset.argentinaPrice);
-    let originalPrice = price.dataset.isDolarized == "dolarized" ? numberToStringUsd(price.dataset.originalPrice) : numberToString(price.dataset.originalPrice);
-
+    let originalPrice = numberToStringUsd(price.dataset.originalPrice);
+    price.addEventListener('click',showSecondaryPrice); 
+    price.style.cursor="pointer";
 
     // Fix para contenedores que intercalan un BR entre precio original y precio en oferta 
-    if (price.classList.contains("was")) sanitizePromoLists();
+    price.classList.contains("was") && sanitizePromoLists();
     
-    // Agrego Listener para switchear precios con click
-    if(!price.classList.contains('discount_original_price') || !price.classList.contains('responsive_secondrow')){
-        price.addEventListener('click',showSecondaryPrice); 
-        price.style.cursor="pointer";
-    }
+    // Si el saldo te alcanza para comprar el juego
+    if(walletBalance > parseFloat(price.dataset.originalPrice)){
+        price.innerHTML = originalPrice + emojiWallet;     
+        price.classList.add("original");
 
-    if(walletBalance > parseFloat(price.dataset.originalPrice) && !price.classList.contains('discount_original_price')){
-
-        // Fix para Search View
-        if(price.matches('.discounted.responsive_secondrow')){
-            let precioTachado = price.querySelector("strike");
-            
-            if(precioTachado) price.innerHTML = `<strike style="color: #888888;">${precioTachado.innerText}</strike> <br> ${originalPrice} ${emojiWallet}`; 
-            price.removeEventListener('click',showSecondaryPrice); 
-        }
-        else{
-            price.innerHTML = originalPrice + emojiWallet;     
-            price.classList.add("original");
-            price.classList.add("jeje");
-
-            if(price.previousElementSibling){
-                if(isInsideString(price.previousElementSibling,"ARS$")) price.previousElementSibling.innerText = numberToStringUsd(price.previousElementSibling.dataset.originalPrice); 
+        // Si tiene un descuento
+        if(price.previousElementSibling){
+            if(isInsideString(price.previousElementSibling,"$")){
+                price.previousElementSibling.classList.add('original');
+                price.previousElementSibling.classList.remove('argentina');
+                price.previousElementSibling.innerText = numberToStringUsd(price.previousElementSibling.dataset.originalPrice); 
             }
         }
     } 
-    else
-    {
-        // Fix para Search View
-        if(price.matches('.discounted.responsive_secondrow')){
-            let precioTachado = price.querySelector("strike");
-            if(precioTachado) price.innerHTML = `<strike style="color: #888888;"> ${argentinizar(calcularImpuestos(stringToNumber(precioTachado)),false)} </strike> <br> ${argentinaPrice} ${emojiMate}`; 
-            price.removeEventListener('click',showSecondaryPrice); 
 
-        } else{
+    // Si el saldo no alcanza
+    else{
+        price.innerHTML = argentinaPrice + emojiMate;
+        price.classList.add("argentina");
 
-            price.innerHTML = argentinaPrice + emojiMate;
-            price.classList.add("argentina");
-
-
-
-
-            if(price.previousElementSibling){
-                if(isInsideString(price.previousElementSibling,"ARS$")) price.previousElementSibling.innerText = numberToString(price.previousElementSibling.dataset.argentinaPrice); 
+        if(price.previousElementSibling){
+            if(isInsideString(price.previousElementSibling,"$")){
+                price.previousElementSibling.classList.remove('original');
+                price.previousElementSibling.classList.add('argentina');
+                price.previousElementSibling.innerText = numberToString(price.previousElementSibling.dataset.argentinaPrice); 
             }
-
         }
     }
 
     // Fix para reprocesar bundles dinámicos cuyo precio se carga de manera asíncrona
     setTimeout(function(){
         if(price.classList.contains('argentina') && !price.innerText.includes("ARS") && price.closest('.dynamic_bundle_description')){
+            setArgentinaPrice(price);
+        }
+
+        if(price.classList.contains('original') && !price.innerText.includes(emojiWallet) && price.closest('.dynamic_bundle_description')){
             setArgentinaPrice(price);
         }
     },1500)
@@ -107,38 +90,24 @@ function showSecondaryPrice(e){
     selectedPrice.classList.add("transition-effect");
     selectedPrice.style.opacity = 0;
     if(selectedPrice.classList.contains("argentina")){
-        switchPrices(selectedPrice,"argentina","original",emojiWallet,selectedPrice.dataset.isDolarized);
+        switchPrices(selectedPrice,"argentina","original",emojiWallet);
     }
     else if(selectedPrice.classList.contains("original")){
-        switchPrices(selectedPrice,"original","argentina",emojiMate,selectedPrice.dataset.isDolarized);
+        switchPrices(selectedPrice,"original","argentina",emojiMate);
     }
 }
 
-function switchPrices(selector,first,second,symbol,isDolarized){
+function switchPrices(selector,first,second,symbol){
     setTimeout(function(){
         selector.style.opacity=1;
         selector.classList.remove(first);
         selector.classList.add(second);
 
-        if(isDolarized == "dolarized"){
-            if(selector.classList.contains("suscription-price")){
-                selector.innerHTML = numberToStringSub(selector.dataset[second+"Price"] + symbol);
-            } else{
-                selector.innerHTML = first == "argentina" ? numberToStringUsd(selector.dataset[second+"Price"] + symbol) : numberToString(selector.dataset[second+"Price"] + symbol)  ;
-            }            
-        }
-
-        else{
-
-            if(selector.classList.contains("suscription-price")){
-                selector.innerHTML = numberToStringSub(selector.dataset[second+"Price"] + symbol);
-            } else{
-                selector.innerHTML = numberToString(selector.dataset[second+"Price"] + symbol) ;
-            }
-
-        }
-
-
+        if(selector.classList.contains("suscription-price")){
+            selector.innerHTML = numberToStringSub(selector.dataset[second+"Price"] + symbol);
+        } else{
+            selector.innerHTML = first == "argentina" ? numberToStringUsd(selector.dataset[second+"Price"] + symbol) : numberToString(selector.dataset[second+"Price"] + symbol)  ;
+        }            
     },250);
 }
 

--- a/chrome_extension/js/global_functions.js
+++ b/chrome_extension/js/global_functions.js
@@ -62,9 +62,10 @@ function renderPrices(price){
         else{
             price.innerHTML = originalPrice + emojiWallet;     
             price.classList.add("original");
+            price.classList.add("jeje");
 
             if(price.previousElementSibling){
-                if(isInsideString(price.previousElementSibling,"ARS$")) price.previousElementSibling.innerText = numberToString(price.previousElementSibling.dataset.originalPrice); 
+                if(isInsideString(price.previousElementSibling,"ARS$")) price.previousElementSibling.innerText = numberToStringUsd(price.previousElementSibling.dataset.originalPrice); 
             }
         }
     } 
@@ -80,19 +81,21 @@ function renderPrices(price){
 
             price.innerHTML = argentinaPrice + emojiMate;
             price.classList.add("argentina");
-            price.classList.add("xd");
-            // price.innerText = 
+
+
+
 
             if(price.previousElementSibling){
                 if(isInsideString(price.previousElementSibling,"ARS$")) price.previousElementSibling.innerText = numberToString(price.previousElementSibling.dataset.argentinaPrice); 
             }
+
         }
     }
 
     // Fix para reprocesar bundles dinámicos cuyo precio se carga de manera asíncrona
     setTimeout(function(){
-        if(price.classList.contains('argentina') && !price.innerText.includes("ARS")){
-            renderPrices(price);
+        if(price.classList.contains('argentina') && !price.innerText.includes("ARS") && price.closest('.dynamic_bundle_description')){
+            setArgentinaPrice(price);
         }
     },1500)
 

--- a/chrome_extension/js/global_functions.js
+++ b/chrome_extension/js/global_functions.js
@@ -40,6 +40,7 @@ function renderPrices(price){
     let argentinaPrice = numberToString(price.dataset.argentinaPrice);
     let originalPrice = price.dataset.isDolarized == "dolarized" ? numberToStringUsd(price.dataset.originalPrice) : numberToString(price.dataset.originalPrice);
 
+
     // Fix para contenedores que intercalan un BR entre precio original y precio en oferta 
     if (price.classList.contains("was")) sanitizePromoLists();
     
@@ -49,7 +50,7 @@ function renderPrices(price){
         price.style.cursor="pointer";
     }
 
-    if(walletBalance > price.dataset.originalPrice && !price.classList.contains('discount_original_price')){
+    if(walletBalance > parseFloat(price.dataset.originalPrice) && !price.classList.contains('discount_original_price')){
 
         // Fix para Search View
         if(price.matches('.discounted.responsive_secondrow')){
@@ -79,6 +80,8 @@ function renderPrices(price){
 
             price.innerHTML = argentinaPrice + emojiMate;
             price.classList.add("argentina");
+            price.classList.add("xd");
+            // price.innerText = 
 
             if(price.previousElementSibling){
                 if(isInsideString(price.previousElementSibling,"ARS$")) price.previousElementSibling.innerText = numberToString(price.previousElementSibling.dataset.argentinaPrice); 

--- a/chrome_extension/js/helpers.js
+++ b/chrome_extension/js/helpers.js
@@ -403,7 +403,7 @@ function steamizar(contenedor, emoji = true) {
     return numberToString(contenedor) + emojiStatus;
 }
 
-const currentChange = "major"; // patch | minor | major
+const currentChange = "patch"; // patch | minor | major
 
 function showUpdate() {
     chrome.storage.local.get(['justUpdated'], function (result) {

--- a/chrome_extension/js/helpers.js
+++ b/chrome_extension/js/helpers.js
@@ -328,7 +328,7 @@ function extractNumberFromString(string){
     let regexFindNumber = /(\d{1,3}(,\d{3})*(\.\d+)?)/;
     let match = string.match(regexFindNumber);
     if(match){
-        return parseFloat(match[0].replace(/,/g, ''));
+        return match[0].replace(/,/g, '');
     }
 
 

--- a/chrome_extension/js/helpers.js
+++ b/chrome_extension/js/helpers.js
@@ -328,14 +328,13 @@ function extractNumberFromString(string){
     let regexFindNumber = /(\d{1,3}(,\d{3})*(\.\d+)?)/;
     let match = string.match(regexFindNumber);
     if(match){
-        return match[0].replace(/,/g, '');
+        return parseFloat(match[0].replace(/,/g, ''));
     }
 
 
 }
 
 function stringToNumber(number, positionArs = 5) {
-
     if(!number.innerText.includes('ARS')){
         return extractNumberFromString(number.innerText);
     }

--- a/chrome_extension/js/subscriptions.js
+++ b/chrome_extension/js/subscriptions.js
@@ -1,8 +1,11 @@
 let precios = document.querySelectorAll(".updateSubscriptionOptionPrice,.transactionRowAmountDue,.itemSubtext,.game_area_purchase_game_dropdown_menu_item_text,.game_area_purchase_game_dropdown_selection span");
-precios.forEach(precio => {
-    precio.innerHTML = precio.innerHTML + " &nbsp;"; // Previene errores
-    check(precio);
-});
+
+// Desactivo función temporalmente
+// precios.forEach(precio => {
+    
+//     precio.innerHTML = precio.innerHTML + " &nbsp;"; // Previene errores
+//     check(precio);
+// });
 let spans = document.querySelectorAll(".suscription-price");
 spans.forEach(span => {
     if(walletBalance < span.innerText){

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,6 +1,6 @@
  {
  	"name": "Steamcito: Steam con impuestos Argentina 2023",
- 	"version": "3.21",
+ 	"version": "3.22",
  	"description": "Muestra todos los productos de la tienda de Steam con todos los impuestos de Argentina incluidos",
  	"manifest_version": 3,
  	"background": {

--- a/firefox_extension/js/cart_functions.js
+++ b/firefox_extension/js/cart_functions.js
@@ -46,7 +46,7 @@
     }
     
     function showCart() {
-        let estimatedTotalDisplay = walletBalance < cartTotal ? "hide" : "show";
+        let estimatedTotalDisplay = walletBalance < parseFloat(cartTotal) ? "hide" : "show";
         let totalMixedDisplay = estimatedTotalDisplay == "hide" && walletBalance != 0 ? "show" : "hide";
     
         let newCart =

--- a/firefox_extension/js/helpers.js
+++ b/firefox_extension/js/helpers.js
@@ -404,7 +404,7 @@ function steamizar(contenedor, emoji = true) {
     return numberToString(contenedor) + emojiStatus;
 }
 
-const currentChange = "major"; // patch | minor | major
+const currentChange = "patch"; // patch | minor | major
 
 function showUpdate() {
     chrome.storage.local.get(['justUpdated'], function (result) {

--- a/firefox_extension/js/subscriptions.js
+++ b/firefox_extension/js/subscriptions.js
@@ -1,8 +1,9 @@
 let precios = document.querySelectorAll(".updateSubscriptionOptionPrice,.transactionRowAmountDue,.itemSubtext,.game_area_purchase_game_dropdown_menu_item_text,.game_area_purchase_game_dropdown_selection span");
-precios.forEach(precio => {
-    precio.innerHTML = DOMPurify.sanitize(precio.innerHTML + " &nbsp;"); // Previene errores
-    check(precio);
-});
+// Desactivo función temporalmente
+// precios.forEach(precio => {
+//     precio.innerHTML = DOMPurify.sanitize(precio.innerHTML + " &nbsp;"); // Previene errores
+//     check(precio);
+// });
 let spans = document.querySelectorAll(".suscription-price");
 spans.forEach(span => {
     if (walletBalance < span.innerText) {

--- a/firefox_extension/manifest.json
+++ b/firefox_extension/manifest.json
@@ -1,6 +1,6 @@
  {
  	"name": "Steamcito: Steam con impuestos Argentina 2023",
- 	"version": "3.21",
+ 	"version": "3.22",
  	"description": "Muestra todos los productos de la tienda de Steam con todos los impuestos de Argentina incluidos",
  	"manifest_version": 2,
  	"background": {


### PR DESCRIPTION
Update centrada en la resolución de bugs:

- Hotfix: Se resuelve bug donde no aparece la cuenta del precio abonando con Saldo Steam Wallet + Tarjeta
- Hotfix: Se resuelve bug donde los juegos en oferta a veces exhiben el texto "ARS" en vez de "USD" cuando tenés saldo Steam Wallet
- Hotfix: Se soluciona bug donde a veces tenés que hacer dos clicks para cambiar de precio original a precio en pesos y viceversa
- Enhancement: Se elimina código innecesario pertinente a la tienda de Steam previa a la dolarización.