### PR TITLE
Hotfix/v341

### DIFF
--- a/chrome_extension/js/global_functions.js
+++ b/chrome_extension/js/global_functions.js
@@ -185,7 +185,7 @@ function renderPrices(price){
     // Fix para reprocesar bundles dinámicos cuyo precio se carga de manera asíncrona
     setTimeout(function(){
         if(price.classList.contains('argentina') && !price.innerText.includes("ARS") && price.closest('.dynamic_bundle_description')){
-            // setArgentinaPrice(price);
+            setArgentinaPrice(price);
         }
 
         if(price.classList.contains('original') && !price.innerText.includes("USD") && price.closest('.dynamic_bundle_description')){

--- a/chrome_extension/js/global_functions.js
+++ b/chrome_extension/js/global_functions.js
@@ -185,10 +185,10 @@ function renderPrices(price){
     // Fix para reprocesar bundles dinámicos cuyo precio se carga de manera asíncrona
     setTimeout(function(){
         if(price.classList.contains('argentina') && !price.innerText.includes("ARS") && price.closest('.dynamic_bundle_description')){
-            setArgentinaPrice(price);
+            // setArgentinaPrice(price);
         }
 
-        if(price.classList.contains('original') && !price.innerText.includes(emojiWallet) && price.closest('.dynamic_bundle_description')){
+        if(price.classList.contains('original') && !price.innerText.includes("USD") && price.closest('.dynamic_bundle_description')){
             setArgentinaPrice(price);
         }
     },1500)

--- a/chrome_extension/js/helpers.js
+++ b/chrome_extension/js/helpers.js
@@ -421,7 +421,7 @@ function steamizar(contenedor, emoji = true) {
     return numberToString(contenedor) + emojiStatus;
 }
 
-const currentChange = "major"; // patch | minor | major
+const currentChange = "patch"; // patch | minor | major
 
 function showUpdate() {
     chrome.storage.local.get(['justUpdated'], function (result) {

--- a/chrome_extension/js/regional_indicator.js
+++ b/chrome_extension/js/regional_indicator.js
@@ -151,7 +151,10 @@ const renderCryptoPrice = (appData) => {
     let cardPrice = (appData.arsPrice * exchangeRate).toFixed(2)
     let cryptoPrice = (appData.arsPrice * cryptoExchangeRate).toFixed(2)
 
-    if(cryptoExchangeRate > exchangeRate || cardPrice - cryptoPrice < 1000  ){
+    console.log("Crypto is", cryptoExchangeRate);
+    console.log("Normal is", exchangeRate);
+
+    if(cryptoExchangeRate > exchangeRate ){
         return;
     }
 

--- a/chrome_extension/js/regional_indicator.js
+++ b/chrome_extension/js/regional_indicator.js
@@ -151,9 +151,6 @@ const renderCryptoPrice = (appData) => {
     let cardPrice = (appData.arsPrice * exchangeRate).toFixed(2)
     let cryptoPrice = (appData.arsPrice * cryptoExchangeRate).toFixed(2)
 
-    console.log("Crypto is", cryptoExchangeRate);
-    console.log("Normal is", exchangeRate);
-
     if(cryptoExchangeRate > exchangeRate ){
         return;
     }

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,6 +1,6 @@
  {
  	"name": "Steamcito: Steam con impuestos Argentina 2024",
- 	"version": "3.40",
+ 	"version": "3.41",
  	"description": "Muestra todos los productos de la tienda de Steam con todos los impuestos de Argentina incluidos",
  	"manifest_version": 3,
  	"background": {

--- a/firefox_extension/js/global_functions.js
+++ b/firefox_extension/js/global_functions.js
@@ -189,7 +189,7 @@ function renderPrices(price){
             setArgentinaPrice(price);
         }
 
-        if(price.classList.contains('original') && !price.innerText.includes(emojiWallet) && price.closest('.dynamic_bundle_description')){
+        if(price.classList.contains('original') && !price.innerText.includes("USD") && price.closest('.dynamic_bundle_description')){
             setArgentinaPrice(price);
         }
     },1500)

--- a/firefox_extension/js/helpers.js
+++ b/firefox_extension/js/helpers.js
@@ -423,7 +423,7 @@ function steamizar(contenedor, emoji = true) {
     return numberToString(contenedor) + emojiStatus;
 }
 
-const currentChange = "major"; // patch | minor | major
+const currentChange = "patch"; // patch | minor | major
 
 function showUpdate() {
     chrome.storage.local.get(['justUpdated'], function (result) {

--- a/firefox_extension/manifest.json
+++ b/firefox_extension/manifest.json
@@ -1,6 +1,6 @@
  {
  	"name": "Steamcito: Steam con impuestos Argentina 2024",
- 	"version": "3.40",
+ 	"version": "3.41",
  	"description": "Muestra todos los productos de la tienda de Steam con todos los impuestos de Argentina incluidos",
  	"manifest_version": 2,
  	"background": {


### PR DESCRIPTION
En este parche menor se solucionan dos inconsistencias:

- Fix: se soluciona un bug en el cual los bundles dinámicos se reprocesaban indefinidamente cuando contabas con saldo para comprarlos.
- Enhancement: Se habilita indicador de cotización del dólar crypto en todos los casos. Se deshabilita sólo cuando tenés saldo suficiente para comprar el juego. 

![reprocesamiento](https://github.com/emilianog94/Steamcito-Precios-Steam-Argentina-Impuestos-Incluidos/assets/38828911/2d730808-bef2-4d0b-ba1b-cd6ab6007cdf)
