### PR TITLE
fix: remove auto-reload after changing payment method settings

### DIFF
--- a/chrome_extension/js/menu.js
+++ b/chrome_extension/js/menu.js
@@ -169,7 +169,6 @@ function changePaymentMethodState(e){
         default: localStorage.setItem('national-tax',60)
             break;
     }
-    window.location.reload()
 }
 
 function changeEmojiState(){

--- a/firefox_extension/js/menu.js
+++ b/firefox_extension/js/menu.js
@@ -176,7 +176,6 @@ function changePaymentMethodState(e){
         default: localStorage.setItem('national-tax',60)
             break;
     }
-    window.location.reload()
 }
 
 function changeEmojiState() {


### PR DESCRIPTION
Buenas, actualmente cada vez que se cambia el metodo de pago se hace un reload de la pagina sin darle al boton de aplicar cambios pero el resto de configuraciones no funcionan de esta manera, adjunto un video del estado actual

https://github.com/emilianog94/Steamcito-Precios-Steam-Argentina-Impuestos-Incluidos/assets/59459088/d3514fc2-b452-47a2-9128-38e19f0c54ba

Se saco el reload() para evitar ese comportamiento y asi es como queda

https://github.com/emilianog94/Steamcito-Precios-Steam-Argentina-Impuestos-Incluidos/assets/59459088/292459d3-0282-4999-90b4-be2f89d5ebdf
