### PR TITLE
feat: 🎨 Funcionalidad para evitar clicks imprevistos con el menú desplegado (background transparente)

### DIFF
--- a/chrome_extension/css/styles.css
+++ b/chrome_extension/css/styles.css
@@ -28,6 +28,9 @@ body.menu-enabled {
 }
 body.menu-enabled .responsive_page_frame {
   filter: blur(0.35em);
+}
+body .responsive_page_frame {
+  filter: none;
   transition: all 0.5s ease;
 }
 
@@ -575,6 +578,14 @@ body.menu-enabled .responsive_page_frame {
   z-index: 100000;
   transition: all 0.25s ease;
   padding: 15px 0;
+}
+.menu-steamcito-background-enabled {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 99999;
 }
 @media (min-width: 1440px) {
   .menu-steamcito {

--- a/chrome_extension/js/menu.js
+++ b/chrome_extension/js/menu.js
@@ -9,6 +9,7 @@ function createMenus(){
     steamcitoIcon && steamcitoIcon.addEventListener('click',showMenu);
 
     let steamcitoMenu = `
+    <div class="menu-steamcito-background"></div>
     <div class="menu-steamcito">
             <div class="internal-menu">
                 <span class="titulo">CONFIGURACIÓN DE STEAMCITO <br><span class="titulo__version"> Versión ${chrome.runtime.getManifest().version}</span></span>
@@ -199,6 +200,7 @@ function changeProvinceTax(){
 
 function showMenu(e){
     menu.classList.add('enabled');
+    menuBackground.classList.add('menu-steamcito-background-enabled');
     document.body.classList.add('menu-enabled');
     document.addEventListener('click',hideMenu);
 }
@@ -206,6 +208,7 @@ function showMenu(e){
 function hideMenu(e){
     if(!menu.contains(e.target) && !steamcitoIcon.contains(e.target)) {
         menu.classList.remove('enabled');
+        menuBackground.classList.remove('menu-steamcito-background-enabled');
         document.body.classList.remove('menu-enabled');
         document.removeEventListener('click',hideMenu);
     }
@@ -242,6 +245,7 @@ createMenus();
 
 // Selecciono los botones del menú y les asigno eventos
 const menu = document.querySelector(".menu-steamcito");
+const menuBackground = document.querySelector(".menu-steamcito-background");
 
 const steamcitoIcon = document.querySelector(".ico-steamcito");
 let selectManualMode = document.querySelector("#modo-manual");

--- a/firefox_extension/css/styles.css
+++ b/firefox_extension/css/styles.css
@@ -28,6 +28,9 @@ body.menu-enabled {
 }
 body.menu-enabled .responsive_page_frame {
   filter: blur(0.35em);
+}
+body .responsive_page_frame {
+  filter: none;
   transition: all 0.5s ease;
 }
 
@@ -571,6 +574,14 @@ body.menu-enabled .responsive_page_frame {
   z-index: 100000;
   transition: all 0.25s ease;
   padding: 15px 0;
+}
+.menu-steamcito-background-enabled {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 99999;
 }
 @media (min-width: 1440px) {
   .menu-steamcito {

--- a/firefox_extension/js/menu.js
+++ b/firefox_extension/js/menu.js
@@ -12,6 +12,7 @@ function createMenus() {
     steamcitoIcon && steamcitoIcon.addEventListener('click', showMenu);
 
     let steamcitoMenu = `
+    <div class="menu-steamcito-background"></div>
     <div class="menu-steamcito">
             <div class="internal-menu">
                 <span class="titulo">CONFIGURACIÓN DE STEAMCITO <br><span class="titulo__version"> Versión ${chrome.runtime.getManifest().version}</span></span>
@@ -206,6 +207,7 @@ function changeProvinceTax() {
 
 function showMenu(e) {
     menu.classList.add('enabled');
+    menuBackground.classList.add('menu-steamcito-background-enabled');
     document.body.classList.add('menu-enabled');
     document.addEventListener('click', hideMenu);
 }
@@ -213,6 +215,7 @@ function showMenu(e) {
 function hideMenu(e) {
     if (!menu.contains(e.target) && !steamcitoIcon.contains(e.target)) {
         menu.classList.remove('enabled');
+        menuBackground.classList.remove('menu-steamcito-background-enabled');
         document.body.classList.remove('menu-enabled');
         document.removeEventListener('click', hideMenu);
     }
@@ -249,6 +252,7 @@ createMenus();
 
 // Selecciono los botones del menú y les asigno eventos
 const menu = document.querySelector(".menu-steamcito");
+const menuBackground = document.querySelector(".menu-steamcito-background");
 
 const steamcitoIcon = document.querySelector(".ico-steamcito");
 let selectManualMode = document.querySelector("#modo-manual");


### PR DESCRIPTION
Hola, sumo unos pequeños cambios:
- Agrego background transparente entre menú enabled y el website para evitar clicks imprevistos al cerrar menú.
- Agrego transición fade-out a la animación de blur aplicado al body.

Estado actual:

https://github.com/user-attachments/assets/9ec01c19-01bd-46f9-813d-281e7ceda17b

Con el background:

https://github.com/user-attachments/assets/4a549a8c-2dab-4337-b529-7691bda78d8f