### PR TITLE
fix: 🐛 evitar cambios en line-height al hacer hover en "Juegos Argentinos" de store_nav

### DIFF
--- a/chrome_extension/css/styles.css
+++ b/chrome_extension/css/styles.css
@@ -1128,6 +1128,7 @@ body.menu-enabled .responsive_page_frame {
 
 .store_nav .tab > span {
   padding: 0 7px !important;
+  line-height: 33px !important;
 }
 
 .store_nav .tab-videojuegos-argentinos span {

--- a/firefox_extension/css/styles.css
+++ b/firefox_extension/css/styles.css
@@ -1150,6 +1150,7 @@ body .responsive_page_frame {
 
 .store_nav .tab > span {
   padding: 0 9px !important;
+  line-height: 33px !important;
 }
 
 .store_nav .tab-videojuegos-argentinos span {


### PR DESCRIPTION
Se corrige un bug en el que, al hacer hover sobre "Juegos Argentinos" en la nav de la tienda, el texto se movía 1 píxel hacia arriba.
Viendo el css de steam, el selector `.store_nav .tab > span` esta duplicado pero el line-height con valores diferentes, desactivando el line-height de 34px parece resolver el bug.

![image](https://github.com/user-attachments/assets/893a3bea-9a75-4d47-a586-dc5f956c1faa)

Antes y después:
 
![ejemplo](https://github.com/user-attachments/assets/b3e462ab-ae64-4b16-9b23-913b4a021d25)

https://github.com/user-attachments/assets/ab16ca92-09d2-42e0-983d-e8c1ee3b34cb


