### PR TITLE
Hacer ocultables barra lateral y juegos argentinos (repost)

### DIFF
--- a/chrome_extension/js/helpers.js
+++ b/chrome_extension/js/helpers.js
@@ -429,6 +429,11 @@ function steamizar(contenedor, emoji = true) {
 
 
 function renderArgentinaShortcut(){
+    let orgulloArgentinoHidden = localStorage.getItem('ocultar-orgullo-argentino');
+    if (orgulloArgentinoHidden == "ocultar") {
+        return;
+    }
+    
     let navbar = document.querySelector('.store_nav');
     if(navbar){
         let navbarFirstItem = navbar.querySelector('div:first-child');

--- a/chrome_extension/js/home.js
+++ b/chrome_extension/js/home.js
@@ -23,6 +23,11 @@ function shuffleArray(array) {
   }; 
 
 function renderOwnedArgentinaGames(gamesIds){
+    let orgulloArgentinoHidden = localStorage.getItem('ocultar-orgullo-argentino');
+    if (orgulloArgentinoHidden == "ocultar") {
+        return;
+    }
+
     gamesIds = shuffleArray(gamesIds)
     let targetItem = document.querySelector('.home_ctn.tab_container')
     if(targetItem){

--- a/chrome_extension/js/menu.js
+++ b/chrome_extension/js/menu.js
@@ -88,9 +88,21 @@ function createMenus(){
                                 <select name="estilo-barra" id="estilo-barra">
                                     <option value="barra-normal">Normal</option>
                                     <option value="barra-minificada">Minificada</option>
+                                    <option value="barra-oculta">Ocultar</option>
                                 </select>
                             </div>
                             <small>Seleccioná "Minificada" para que la información de cotización del dólar y precios regionales ocupe menos espacio.</small>
+                        </div>
+
+                        <div class="opcion" id="orgullo-argentino">
+                            <div>
+                                <label for="ocultar-orgullo-argentino">Juegos Argentinos</label>
+                                <select name="ocultar-orgullo-argentino" id="ocultar-orgullo-argentino">
+                                    <option value="mostrar">Mostrar</option>
+                                    <option value="ocultar">Ocultar</option>
+                                </select>
+                            </div>
+                            <small>Agrega insignias a juegos desarrollados en Argentina y detecta los juegos argentinos en tu biblioteca.</small>
                         </div>
 
                     </div>
@@ -132,12 +144,17 @@ function setInitialLocalStates(){
     localStorage.getItem('estilo-barra') ? selectBarStyle.value=localStorage.getItem('estilo-barra') : localStorage.removeItem('estilo-barra');
     localStorage.getItem('metodo-de-pago') ? selectPaymentMethod.value=localStorage.getItem('metodo-de-pago') : localStorage.setItem('metodo-de-pago','steamcito-cotizacion-tarjeta');
     localStorage.getItem('ocultar-crypto') ? checkboxDolarCrypto.value=localStorage.getItem('ocultar-crypto') : localStorage.removeItem('ocultar-crypto');
+    localStorage.getItem('ocultar-orgullo-argentino') ? checkboxOrgulloArgentino.value=localStorage.getItem('ocultar-orgullo-argentino') : localStorage.removeItem('ocultar-orgullo-argentino');
 }
 
 
 
 function changeBarStyleState(){
     selectBarStyle.value == 'barra-normal' ? localStorage.setItem('estilo-barra','barra-normal') : localStorage.setItem('estilo-barra','barra-minificada');
+    let style = selectBarStyle.value;
+    if (style == 'barra-normal') localStorage.setItem('estilo-barra','barra-normal');
+    if (style == 'barra-oculta') localStorage.setItem('estilo-barra','barra-oculta');
+    if (style == 'barra-minificada') localStorage.setItem('estilo-barra','barra-minificada');
 }
 
 function changePaymentMethodState(e){
@@ -171,6 +188,10 @@ function changePaymentMethodState(e){
 
 function changeDolarCryptoVisibility() {
     checkboxDolarCrypto.value == 'mostrar' ? localStorage.setItem('ocultar-crypto','mostrar') : localStorage.setItem('ocultar-crypto','ocultar');
+}
+
+function changeJuegosArgentinosVisibility() {
+    checkboxOrgulloArgentino.value == 'mostrar' ? localStorage.setItem('ocultar-orgullo-argentino','mostrar') : localStorage.setItem('ocultar-orgullo-argentino','ocultar');
 }
 
 function changeManualModeState(){
@@ -232,11 +253,13 @@ let selectManualMode = document.querySelector("#modo-manual");
 let selectBarStyle = document.querySelector("#estilo-barra");
 let selectPaymentMethod = document.querySelector('#metodo-de-pago-opciones');
 let checkboxDolarCrypto = document.querySelector("#ocultar-crypto");
+let checkboxOrgulloArgentino = document.querySelector("#ocultar-orgullo-argentino");
 
 selectManualMode.addEventListener('input', changeManualModeState);
 selectBarStyle.addEventListener('input',changeBarStyleState);
 selectPaymentMethod.addEventListener('input', changePaymentMethodState);
 checkboxDolarCrypto.addEventListener('change', changeDolarCryptoVisibility);
+checkboxOrgulloArgentino.addEventListener('change', changeJuegosArgentinosVisibility);
 
 let nationalTax = document.querySelector("#national-tax");
 nationalTax.addEventListener('input',changeNationalTax);

--- a/chrome_extension/js/regional_indicator.js
+++ b/chrome_extension/js/regional_indicator.js
@@ -36,6 +36,11 @@ const isFromArgentina = () => {
 }
 
 const renderArgentinaIndicator = (matchingGame) => {
+    let orgulloArgentinoHidden = localStorage.getItem('ocultar-orgullo-argentino');
+    if (orgulloArgentinoHidden == "ocultar") {
+        return;
+    }
+    
     let gameName = document.querySelector('#appHubAppName');
     let targetContainer = document.querySelector('.leftcol.game_description_column');
     
@@ -313,6 +318,10 @@ const renderCryptoPrice = async (appData) => {
    }
 
 const renderExchangeIndicator = (exchangeRate,exchangeRateDate,exchangeRateCrypto,exchangeRateCryptoDate,exchangeRateMep,exchangeRateMepDate,tarjetaTax,cryptoTax,mepTax) => {
+    if (indicatorStyle == "barra-oculta") {
+        return;
+    }
+    
     let sidebar = document.querySelector('.rightcol.game_meta_data');
 
     let staticExchangeRate = exchangeRate;
@@ -438,6 +447,10 @@ const renderPriceIndicators = (appData) => {
 
 
 const renderRegionalIndicator = (appData, exchangeRate) => {
+    if (indicatorStyle == "barra-oculta") {
+        return;
+    }
+    
     let sidebar = document.querySelector('.rightcol.game_meta_data');
 
     let container =

--- a/firefox_extension/js/helpers.js
+++ b/firefox_extension/js/helpers.js
@@ -429,6 +429,11 @@ function steamizar(contenedor, emoji = true) {
 }
 
 function renderArgentinaShortcut(){
+    let orgulloArgentinoHidden = localStorage.getItem('ocultar-orgullo-argentino');
+    if (orgulloArgentinoHidden == "ocultar") {
+        return;
+    }
+    
     let navbar = document.querySelector('.store_nav');
     if(navbar){
         let navbarFirstItem = navbar.querySelector('div:first-child');

--- a/firefox_extension/js/home.js
+++ b/firefox_extension/js/home.js
@@ -23,6 +23,11 @@ function shuffleArray(array) {
   }; 
 
 function renderOwnedArgentinaGames(gamesIds){
+    let orgulloArgentinoHidden = localStorage.getItem('ocultar-orgullo-argentino');
+    if (orgulloArgentinoHidden == "ocultar") {
+        return;
+    }
+
     gamesIds = shuffleArray(gamesIds)
     let targetItem = document.querySelector('.home_ctn.tab_container')
     if(targetItem){

--- a/firefox_extension/js/menu.js
+++ b/firefox_extension/js/menu.js
@@ -89,9 +89,21 @@ function createMenus() {
                                 <select name="estilo-barra" id="estilo-barra">
                                     <option value="barra-normal">Normal</option>
                                     <option value="barra-minificada">Minificada</option>
+                                    <option value="barra-oculta">Ocultar</option>
                                 </select>
                             </div>
                             <small>Seleccioná "Minificada" para que la información de cotización del dólar y precios regionales ocupe menos espacio.</small>
+                        </div>
+
+                        <div class="opcion" id="orgullo-argentino">
+                            <div>
+                                <label for="ocultar-orgullo-argentino">Juegos Argentinos</label>
+                                <select name="ocultar-orgullo-argentino" id="ocultar-orgullo-argentino">
+                                    <option value="mostrar">Mostrar</option>
+                                    <option value="ocultar">Ocultar</option>
+                                </select>
+                            </div>
+                            <small>Agrega insignias a juegos desarrollados en Argentina y detecta los juegos argentinos en tu biblioteca.</small>
                         </div>
 
                     </div>
@@ -133,11 +145,14 @@ function setInitialLocalStates() {
     localStorage.getItem('estilo-barra') ? selectBarStyle.value=localStorage.getItem('estilo-barra') : localStorage.removeItem('estilo-barra');
     localStorage.getItem('metodo-de-pago') ? selectPaymentMethod.value=localStorage.getItem('metodo-de-pago') : localStorage.setItem('metodo-de-pago','steamcito-cotizacion-tarjeta');
     localStorage.getItem('ocultar-crypto') ? checkboxDolarCrypto.value=localStorage.getItem('ocultar-crypto') : localStorage.removeItem('ocultar-crypto');
-
+    localStorage.getItem('ocultar-orgullo-argentino') ? checkboxOrgulloArgentino.value=localStorage.getItem('ocultar-orgullo-argentino') : localStorage.removeItem('ocultar-orgullo-argentino');
 }
 
 function changeBarStyleState(){
-    selectBarStyle.value == 'barra-normal' ? localStorage.setItem('estilo-barra','barra-normal') : localStorage.setItem('estilo-barra','barra-minificada');
+    let style = selectBarStyle.value;
+    if (style == 'barra-normal') localStorage.setItem('estilo-barra','barra-normal');
+    if (style == 'barra-oculta') localStorage.setItem('estilo-barra','barra-oculta');
+    if (style == 'barra-minificada') localStorage.setItem('estilo-barra','barra-minificada');
 }
 
 function changePaymentMethodState(e){
@@ -172,6 +187,10 @@ function changePaymentMethodState(e){
 
 function changeDolarCryptoVisibility() {
     checkboxDolarCrypto.value == 'mostrar' ? localStorage.setItem('ocultar-crypto','mostrar') : localStorage.setItem('ocultar-crypto','ocultar');
+}
+
+function changeJuegosArgentinosVisibility() {
+    checkboxOrgulloArgentino.value == 'mostrar' ? localStorage.setItem('ocultar-orgullo-argentino','mostrar') : localStorage.setItem('ocultar-orgullo-argentino','ocultar');
 }
 
 function changeManualModeState() {
@@ -232,11 +251,13 @@ let selectManualMode = document.querySelector("#modo-manual");
 let selectBarStyle = document.querySelector("#estilo-barra");
 let selectPaymentMethod = document.querySelector('#metodo-de-pago-opciones');
 let checkboxDolarCrypto = document.querySelector("#ocultar-crypto");
+let checkboxOrgulloArgentino = document.querySelector("#ocultar-orgullo-argentino");
 
 selectManualMode.addEventListener('input', changeManualModeState);
 selectBarStyle.addEventListener('input',changeBarStyleState);
 selectPaymentMethod.addEventListener('input', changePaymentMethodState);
 checkboxDolarCrypto.addEventListener('change', changeDolarCryptoVisibility);
+checkboxOrgulloArgentino.addEventListener('change', changeJuegosArgentinosVisibility);
 
 let nationalTax = document.querySelector("#national-tax");
 nationalTax.addEventListener('input', changeNationalTax);

--- a/firefox_extension/js/regional_indicator.js
+++ b/firefox_extension/js/regional_indicator.js
@@ -36,6 +36,11 @@ const isFromArgentina = () => {
 }
 
 const renderArgentinaIndicator = (matchingGame) => {
+    let orgulloArgentinoHidden = localStorage.getItem('ocultar-orgullo-argentino');
+    if (orgulloArgentinoHidden == "ocultar") {
+        return;
+    }
+
     let gameName = document.querySelector('#appHubAppName');
     let targetContainer = document.querySelector('.leftcol.game_description_column');
 
@@ -307,6 +312,10 @@ const renderCryptoPrice = async (appData) => {
    }
 
 const renderExchangeIndicator = (exchangeRate,exchangeRateDate,exchangeRateCrypto,exchangeRateCryptoDate,exchangeRateMep,exchangeRateMepDate,tarjetaTax,cryptoTax,mepTax) => {
+    if (indicatorStyle == "barra-oculta") {
+        return;
+    }
+    
     let sidebar = document.querySelector('.rightcol.game_meta_data');
 
     let staticExchangeRate = exchangeRate;
@@ -431,6 +440,10 @@ const renderPriceIndicators = (appData) => {
 }
 
 const renderRegionalIndicator = (appData, exchangeRate) => {
+    if (indicatorStyle == "barra-oculta") {
+        return;
+    }
+    
     let sidebar = document.querySelector('.rightcol.game_meta_data');
 
     let container =


### PR DESCRIPTION
En la configuración de Steamcito:
- Agrega "Ocultar" a la opción "Información en barra lateral" que oculta la barra con información de precio regional y exchanges
- Agrega opción "Juegos Argentinos" con mostrar/ocultar, puesta en mostrar por defecto, que muestra u oculta:
	* La insignia de reconocimiento de juego argentino
	* La feed de juegos argentinos en la home page
	* El shortcut a https://videojuegosargentinos.com.ar/ en la nav

Tal vez tengas que cambiar el nombre/descripción de la nueva opción, no se me ocurrieron mejores.
También agrupé todo lo "argentino" en una sola, no sé si estarás de acuerdo.

Closes #180 